### PR TITLE
added error handling

### DIFF
--- a/scripts/chartHelper.js
+++ b/scripts/chartHelper.js
@@ -8,6 +8,12 @@ function drawOffenseCountChart(
   min,
   labels
 ) {
+  //make sure the 404 image is hidden before painitng the chart
+  let $notFoundSpan = $('.' + 'offenseCountChart' + 'NotFound');
+  if (!$notFoundSpan.hasClass('hide')) {
+    $notFoundSpan.addClass('hide');
+  }
+
   new Chart(document.getElementById('offenseCountChart'), {
     type: 'line',
     data: {
@@ -42,4 +48,18 @@ function drawOffenseCountChart(
       }
     }
   });
+}
+
+function noDataFound(canvasId) {
+  // let errorSpan = document.createElement('span');
+  // //add a 404 data not found message to it
+  // let errorPararaph = document.createElement('p');
+  // errorPararaph.setAttribute('class', 'title is-2');
+  // errorPararaph.textContent = '404 Data Not Found! Please try another query.';
+  // //font-awesome image
+  // let errorIcon = document.createElement('i');
+  // errorIcon.setAttribute('class', 'fas fa-exclamation-triangle')
+  // //<i class="fas fa-exclamation-triangle"></i>
+  //add to canvas
+  $('.' + canvasId + 'NotFound').removeClass('hide');
 }

--- a/scripts/crimeApi.js
+++ b/scripts/crimeApi.js
@@ -43,9 +43,17 @@ const crimeApi = {
   getOffenseCountByLocation: function(offenseType, countByLocation) {
     fetch(crimeApiUrls.countByOffenseUrl(offenseType, countByLocation))
       .then(parseResponse)
-      .then(function(data) {
-        console.log(data);
-        let parsedData = parseOffenseCountDataSet(data);
+      .then(function(apiDataObj) {
+        console.log(apiDataObj);
+        if (apiDataObj.data.length === 0) {
+          throw new Error(
+            'No data found for offense type: ' +
+              offenseType +
+              ' at location :' +
+              countByLocation.getLocationType()
+          );
+        }
+        let parsedData = parseOffenseCountDataSet(apiDataObj);
         drawOffenseCountChart(
           parsedData.trimmedDataSet,
           'Crime Count',
@@ -57,7 +65,7 @@ const crimeApi = {
       })
       .catch(error => {
         console.error('There was a problem with the fetch operation:', error);
-        // return erroHandler(error);
+        noDataFound('offenseCountChart');
       });
   },
   getOffenderCountByProperty: function(
@@ -173,6 +181,16 @@ class CountByLocation {
       return `regions/${this.regionName}`;
     } else {
       return `states/${this.statecode}`;
+    }
+  }
+
+  getLocationType() {
+    if (this.getNationalCount) {
+      return 'national';
+    } else if (this.getCountByRegion) {
+      return `region ${this.regionName}`;
+    } else {
+      return `state ${this.statecode}`;
     }
   }
 }


### PR DESCRIPTION
Sometimes the API returns an empty data-set. The reason, for example, could be that a particular state did not provide data for a specific crime.
In such a case we need to show 404 data not found instead of trying to paint a graph with empty data-set.